### PR TITLE
(fix) [P6-2227] Use erlang:timestamp/1 instead of deprecated erlang:now/1

### DIFF
--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -238,5 +238,5 @@ return(C, #state{connections = Connections, monitors = Monitors, waiting = Waiti
 
 %% Return the current time in seconds, used for timeouts.
 now_secs() ->
-    {M,S,_M} = erlang:now(),
+    {M,S,_M} = erlang:timestamp(),
     M*1000 + S.


### PR DESCRIPTION
For OTP 20.1