### PR TITLE
(fix) #noticket Change pool type from sup to worker 

### DIFF
--- a/src/epgsql_pool_sup.erl
+++ b/src/epgsql_pool_sup.erl
@@ -48,7 +48,7 @@ init([]) ->
      {{simple_one_for_one, 2, 60},
       [{pool,
         {pgsql_pool, start_link, []},
-        transient, 2000, supervisor,
+        transient, 2000, worker,
         [pgsql_pool]}]}}.
 
 %% ===================================================================


### PR DESCRIPTION
relup thinks pool is a supervisor, when it is not